### PR TITLE
Update GH Actions workflow names

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,7 @@
 name: Integration Test
 on: [push]
 jobs:
-  build:
+  integration_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,7 +1,7 @@
 name: Run Unit Tests
 on: [push]
 jobs:
-  unittests:
+  unit_tests:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.9


### PR DESCRIPTION
This is to be able to enforce both unit_tests and integration_tests before being able to merge a PR to master